### PR TITLE
Add lambda warmup plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
     "serverless": "^1.34.1",
     "serverless-domain-manager": "^2.6.6",
     "serverless-python-requirements": "^4.2.5"
+  },
+  "dependencies": {
+    "serverless-plugin-warmup": "^4.2.0-rc.1"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,7 @@ functions:
         - subnet-047fe21bec462bcc5
         - subnet-038478ac6e33b3974
         - subnet-06c744148461a661c
+    warmup: true
 
 custom:
   customDomain:
@@ -55,7 +56,63 @@ custom:
     SPOTIFY_CLIENT_ID: ${env:SPOTIFY_CLIENT_ID}
     SPOTIFY_CLIENT_SECRET: ${env:SPOTIFY_CLIENT_SECRET}
     SUNLIGHT_SERVICE_API_KEY: ${env:SUNLIGHT_SERVICE_API_KEY}
+  warmup:
+    schedule: rate(15 minutes)
+    prewarm: true
+    role: morningCdWarmupRole
+
+# this is all for warmup
+resources:
+  Resources:
+    morningCdWarmupRole:
+      Type: AWS::IAM::Role
+      Properties:
+        RoleName: MorningCdWarmupRole
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        Policies:
+          - PolicyName: invokeMorningCdLambdas
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource:
+                    - 'Fn::Join':
+                      - ':'
+                      -
+                        - 'arn:aws:logs'
+                        - Ref: 'AWS::Region'
+                        - Ref: 'AWS::AccountId'
+                        - 'log-group:/aws/lambda/*:*:*'
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterface
+                    - ec2:DescribeNetworkInterfaces
+                    - ec2:DetachNetworkInterface
+                    - ec2:DeleteNetworkInterface
+                  Resource: "*"
+                - Effect: 'Allow'
+                  Action:
+                    - 'lambda:InvokeFunction'
+                  Resource:
+                  - Fn::Join:
+                    - ':'
+                    - - arn:aws:lambda
+                      - Ref: AWS::Region
+                      - Ref: AWS::AccountId
+                      - function:${self:service}-${opt:stage, self:provider.stage}-*
 
 plugins:
   - serverless-python-requirements
   - serverless-domain-manager
+  - serverless-plugin-warmup

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,7 +915,7 @@ fs-extra@^0.26.7:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -1992,6 +1992,14 @@ serverless-domain-manager@^2.6.6:
   dependencies:
     aws-sdk "^2.177.0"
     chalk "^2.0.1"
+
+serverless-plugin-warmup@^4.2.0-rc.1:
+  version "4.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-4.2.0-rc.1.tgz#8eca8562f27d2f41d275f40d687f377a7cb1f6f9"
+  integrity sha512-po2hmHR5lsqhViF8dSjwyRLFUPk7sFAO/ICicMRhReXIAVlwVoSEZpy19AByLicd+bzELt7CsPRVSueWcAqY8Q==
+  dependencies:
+    bluebird "^3.5.0"
+    fs-extra "^7.0.1"
 
 serverless-python-requirements@^4.2.5:
   version "4.2.5"


### PR DESCRIPTION
Listens requires rds access and therefore has to be in a VPC. VPCs
have super slow cold starts, so we occassionally warm up the function.