### PR TITLE
Create new warmup role for listens

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -59,15 +59,15 @@ custom:
   warmup:
     schedule: rate(15 minutes)
     prewarm: true
-    role: morningCdWarmupRole
+    role: morningCdListensWarmupRole
 
 # this is all for warmup
 resources:
   Resources:
-    morningCdWarmupRole:
+    morningCdListensWarmupRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: MorningCdWarmupRole
+        RoleName: MorningCdListensWarmupRole
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
At some point I should probably make one warmup role for warming up
all morning-cd microservices that need warmups.

https://circleci.com/gh/zhammer/morning-cd-listens/162
An error occurred: morningCdWarmupRole - MorningCdWarmupRole already
exists in stack