### PR TITLE
Intercept warmup events

### DIFF
--- a/listens/delivery/aws_lambda/rest.py
+++ b/listens/delivery/aws_lambda/rest.py
@@ -18,6 +18,7 @@ if os.environ.get('AWS_EXECUTION_ENV'):
     )
 
 
+@util.intercept_warmup_events
 def handler(event: Dict, context: Dict) -> Dict:
     """Routing all handlers through one aws function means we only have to keep one lambda 'warm'.
     """

--- a/listens/delivery/aws_lambda/types.py
+++ b/listens/delivery/aws_lambda/types.py
@@ -1,0 +1,4 @@
+from typing import Callable, Dict
+
+
+AwsHandler = Callable[[Dict, Dict], Dict]

--- a/listens/delivery/aws_lambda/util.py
+++ b/listens/delivery/aws_lambda/util.py
@@ -1,10 +1,11 @@
 import json
 from datetime import datetime
 from functools import wraps
-from typing import Callable, Dict, NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
 
 from listens.context import Context
 from listens.definitions import Listen, ListenInput, MusicProvider, SortOrder, exceptions
+from listens.delivery.aws_lambda.types import AwsHandler
 from listens.gateways.db import SqlAlchemyDbGateway
 from listens.gateways.music import SpotifyGateway
 from listens.gateways.sunlight import SunlightServiceGateway
@@ -68,9 +69,6 @@ def pluck_listen_input(raw_listen_input: Dict, current_time_utc: datetime) -> Li
         iana_timezone=raw_listen_input['iana_timezone'],
         listen_time_utc=current_time_utc
     )
-
-
-AwsHandler = Callable[[Dict, Dict], Dict]
 
 
 def catch_listens_service_errors(func: AwsHandler) -> AwsHandler:


### PR DESCRIPTION
https://github.com/FidelLimited/serverless-plugin-warmup invokes the lambda with the request event `{'source': 'serverless-plugin-warmup'}`. This PR adds a decorator to intercept these messages and immediately return a `204 No Content` response rather than processing and failing.

`204` is used mainly to distinguish from real success responses.